### PR TITLE
docs(readme): add procedure to launch the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,62 @@ This project relies on several modern technologies to ensure optimal performance
 - **JWT (JSON Web Token)**: Used for secure user authentication, allowing session management without storing sensitive information on the server.
 - **MongoDB**: A NoSQL database chosen for its flexibility and ability to dynamically manage documents, which perfectly suits the evolving nature of interactive stories.
 
+## Prerequisites
+- **JDK** Version 17 or higher.
+- **Maven** Version 3.6.3 or higher.
+- **Docker** If you want to run MongoDB via Docker.
+- **Postman** For testing the API endpoints.
+
 ## HATEOAS
 This API incorporates the HATEOAS principle, meaning that each response includes hypermedia links to other possible actions. This allows clients to interact with the API dynamically, without needing to know all available URLs in advance. For example, when a user starts a new adventure, the response will include links to available choices, progress tracking, and other relevant features. This approach promotes intuitive navigation and facilitates the onboarding of new users by making documentation less critical.
+
+## Dependencies
+Here are the main dependencies used in the project:
+
+- Spring Boot: `3.3.2`
+- spring-boot-starter-web: For creating RESTful web applications.
+- spring-boot-starter-data-mongodb: For integration with MongoDB.
+- spring-boot-starter-security: For application security.
+- spring-boot-starter-hateoas: For implementing HATEOAS principles.
+- spring-boot-devtools: For live development (optional).
+- spring-boot-starter-test: For unit and integration testing.
+- Mockito: `5.0.0` (or another stable version) for unit testing.
+- JJWT: For managing JSON Web Tokens (JWT).
+
+## Getting Started
+
+### Installation Instructions
+1. Clone the repository:
+    ```bash
+   git clone https://github.com/your-username/you-are-the-hero.git
+    cd you-are-the-hero
+   ```
+
+2. Install the dependencies:
+    ```bash
+    mvn install
+   ```
+3. Start MongoDB using Docker:
+    ```bash
+    docker run --name mongodb -d -p 27017:27017 mongo
+   ```
+   or build the Docker image for your Spring Boot application (make sure you're in the project's root directory where the Dockerfile is located):
+    ```bash
+    docker build -t you-are-the-hero .
+   ```
+   Start the application using Docker Compose:
+    ```bash
+    docker-compose up -d
+   ```
+4. Access the application:
+
+- The Spring Boot application will be accessible at `http://localhost:8080`.
+- MongoDB will be accessible at `mongodb://localhost:27017`.
+
+To stop the services, you can use:
+```bash
+docker-compose down
+   ```
 
 ## Contributing
 


### PR DESCRIPTION
update README with setup instructions

- Added detailed instructions for cloning the repository, installing dependencies, and starting the application using Docker.
- Included prerequisites for running the project, such as JDK, Maven, Docker, and Postman.

fix #1 