### PR TITLE
test: Added unit tests for Scene Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Ignore all files in the .idea directory
+.idea/
+
+# Ignore all compiled Java classes
+*.class
+
+# Ignore target directory (Maven build output)
+target/
+
+# Ignore Maven specific files
+pom.properties
+*.jar
+*.xml
+
+# Ignore Surefire reports
+surefire-reports/

--- a/src/test/java/fr/nelson/you_are_the_hero/service/SceneServiceTest.java
+++ b/src/test/java/fr/nelson/you_are_the_hero/service/SceneServiceTest.java
@@ -1,0 +1,92 @@
+package fr.nelson.you_are_the_hero.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import fr.nelson.you_are_the_hero.model.dto.AddSceneDto;
+import fr.nelson.you_are_the_hero.model.Choice;
+import fr.nelson.you_are_the_hero.model.db.Scene;
+import fr.nelson.you_are_the_hero.repository.SceneRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+public class SceneServiceTest {
+
+    @Mock
+    private SceneRepository sceneRepository;
+
+    @InjectMocks
+    private SceneService sceneService;
+
+    @Test
+    void testAddNewScene_Success() {
+        // Arrange
+        String parentId = "parent123";
+        AddSceneDto sceneToAdd = new AddSceneDto("New scene description", "New choice");
+        Scene parentScene = new Scene("Parent scene", null);
+        parentScene.setId(parentId);
+        Scene childScene = new Scene("New scene description", parentId);
+        childScene.setId("child456");
+
+        when(sceneRepository.findById(parentId)).thenReturn(Optional.of(parentScene));
+        when(sceneRepository.save(any(Scene.class))).thenReturn(childScene).thenReturn(parentScene);
+
+        // Act
+        Scene result = sceneService.addNewScene(parentId, sceneToAdd);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(1, result.getChoices().size());
+        assertEquals("New choice", result.getChoices().get(0).getDescription());
+        assertEquals("child456", result.getChoices().get(0).getNextSceneId());
+        verify(sceneRepository, times(2)).save(any(Scene.class));
+    }
+
+    @Test
+    void testAddNewScene_ParentSceneNotFound() {
+        // Arrange
+        String parentId = "nonexistent";
+        AddSceneDto sceneToAdd = new AddSceneDto("New scene description", "New choice");
+
+        when(sceneRepository.findById(parentId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RuntimeException.class, () -> sceneService.addNewScene(parentId, sceneToAdd));
+    }
+
+    @Test
+    void testGetSceneById_Success() {
+        // Arrange
+        String sceneId = "scene123";
+        Scene expectedScene = new Scene("Test scene", null);
+        expectedScene.setId(sceneId);
+
+        when(sceneRepository.findById(sceneId)).thenReturn(Optional.of(expectedScene));
+
+        // Act
+        Scene result = sceneService.getSceneById(sceneId);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(sceneId, result.getId());
+        assertEquals("Test scene", result.getDescription());
+    }
+
+    @Test
+    void testGetSceneById_SceneNotFound() {
+        // Arrange
+        String sceneId = "nonexistent";
+
+        when(sceneRepository.findById(sceneId)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(RuntimeException.class, () -> sceneService.getSceneById(sceneId));
+    }
+}


### PR DESCRIPTION
The following tasks are completed in this pull request. Additionally, I will be attaching a snapshot for the passing of the tests. Please let me know if there are any additional tasks or improvements that need to be addressed. :)

### Task Checklist for `addNewScene` Method

- [x] **Verify that a new scene can be added successfully to an existing parent scene.**
- [x] **Ensure that a Scene is created and associated with the correct parent scene.**
- [x] **Validate that the method throws an exception when trying to add a scene to a non-existent parent scene.**
- [x] **Check that the choices are correctly added to the parent scene.**

### Task Checklist for `getSceneById` Method

- [x] **Test successful retrieval of a scene by its ID when it exists.**
- [x] **Validate that it throws a RuntimeException when the scene does not exist.**

![Screenshot from 2024-09-28 14-36-10](https://github.com/user-attachments/assets/25ca306a-5c5b-4def-8bc0-81dfd5e26201)

Closes Issue No. **#9 Write Unit Tests for SceneService**
