### PR TITLE
fix(jwtutil): changing extractAllClaims method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.3.4</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
 	<groupId>fr.nelson</groupId>
 	<artifactId>you-are-the-hero</artifactId>
@@ -76,7 +76,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson if you prefer -->
+			<artifactId>jjwt-jackson</artifactId>
 			<version>${jjwt.version}</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
### Context:
This PR aims to fix an issue (Fixes #19)  that arose after updating dependencies, particularly the jjwt library. The previous implementation of the extractAllClaims method in the JwtUtil class was no longer functional.

### Changes Made:

I replaced the old extractAllClaims method with a new implementation to ensure compatibility with the latest versions of the jjwt library. Here’s the new method:

```java
private Claims extractAllClaims(String token) {
    return Jwts.parser()
            .verifyWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)))
            .build().parseSignedClaims(token)
            .getPayload();
}
```