### PR TITLE
feat(security): implement refresh token system with tests

### DIFF
--- a/src/main/java/fr/nelson/you_are_the_hero/exception/InvalidCredentialsException.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/exception/InvalidCredentialsException.java
@@ -1,0 +1,7 @@
+package fr.nelson.you_are_the_hero.exception;
+
+public class InvalidCredentialsException extends Exception{
+    public InvalidCredentialsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/exception/InvalidTokenException.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package fr.nelson.you_are_the_hero.exception;
+
+public class InvalidTokenException extends Exception {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/exception/TokenExpiredException.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/exception/TokenExpiredException.java
@@ -1,0 +1,7 @@
+package fr.nelson.you_are_the_hero.exception;
+
+public class TokenExpiredException extends RuntimeException {
+    public TokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/model/db/RefreshToken.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/model/db/RefreshToken.java
@@ -1,0 +1,55 @@
+package fr.nelson.you_are_the_hero.model.db;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document
+public class RefreshToken {
+    @Id
+    private String id;
+
+    private String token;
+
+    @DBRef
+    private AppUser appUser;
+
+    private Instant expireAt;
+
+    public RefreshToken() {
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public AppUser getAppUser() {
+        return appUser;
+    }
+
+    public void setAppUser(AppUser appUser) {
+        this.appUser = appUser;
+    }
+
+    public Instant getExpireAt() {
+        return expireAt;
+    }
+
+    public void setExpireAt(Instant expireAt) {
+        this.expireAt = expireAt;
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/model/dto/AuthResponseDto.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/model/dto/AuthResponseDto.java
@@ -1,0 +1,29 @@
+package fr.nelson.you_are_the_hero.model.dto;
+
+import org.springframework.hateoas.RepresentationModel;
+
+public class AuthResponseDto extends RepresentationModel<AuthResponseDto> {
+    private String accessToken;
+    private String refreshToken;
+
+    public AuthResponseDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/model/dto/RefreshTokenDto.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/model/dto/RefreshTokenDto.java
@@ -1,0 +1,13 @@
+package fr.nelson.you_are_the_hero.model.dto;
+
+public class RefreshTokenDto {
+    String token;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/model/dto/message/MessageDto.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/model/dto/message/MessageDto.java
@@ -5,6 +5,9 @@ import org.springframework.hateoas.RepresentationModel;
 public class MessageDto extends RepresentationModel<MessageDto> {
     private String message;
 
+    public MessageDto() {
+    }
+
     public MessageDto(String message) {
         this.message = message;
     }

--- a/src/main/java/fr/nelson/you_are_the_hero/repository/RefreshTokenRepository.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package fr.nelson.you_are_the_hero.repository;
+
+import fr.nelson.you_are_the_hero.model.db.RefreshToken;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends MongoRepository<RefreshToken, String> {
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByToken(String token);
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/service/AuthenticationService.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/service/AuthenticationService.java
@@ -64,8 +64,7 @@ public class AuthenticationService {
     }
 
     public AuthResponseDto refreshAccessToken(String refreshToken) throws InvalidTokenException, TokenExpiredException {
-        RefreshToken storedRefreshToken = refreshTokenRepository.findByToken(refreshToken)
-                .orElseThrow(() -> new InvalidTokenException("Invalid refresh token"));
+        RefreshToken storedRefreshToken = refreshTokenService.getRefreshToken(refreshToken);
 
         if (storedRefreshToken.getExpireAt().isBefore(Instant.now())) {
             refreshTokenService.deleteRefreshToken(storedRefreshToken.getToken());
@@ -83,4 +82,5 @@ public class AuthenticationService {
 
         return new AuthResponseDto(newAccessToken, newRefreshToken);
     }
+
 }

--- a/src/main/java/fr/nelson/you_are_the_hero/service/AuthenticationService.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/service/AuthenticationService.java
@@ -1,17 +1,24 @@
 package fr.nelson.you_are_the_hero.service;
 
+import fr.nelson.you_are_the_hero.exception.InvalidCredentialsException;
+import fr.nelson.you_are_the_hero.exception.InvalidTokenException;
+import fr.nelson.you_are_the_hero.exception.TokenExpiredException;
+import fr.nelson.you_are_the_hero.model.db.AppUser;
+import fr.nelson.you_are_the_hero.model.db.RefreshToken;
+import fr.nelson.you_are_the_hero.model.dto.AuthResponseDto;
+import fr.nelson.you_are_the_hero.repository.RefreshTokenRepository;
 import fr.nelson.you_are_the_hero.utility.JwtUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.coyote.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.time.Instant;
 
 @Service
 public class AuthenticationService {
@@ -25,23 +32,55 @@ public class AuthenticationService {
     @Autowired
     private JwtUtil jwtUtil;
 
-    public String authenticateUser(String username, String password) throws Exception {
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserService userService;
+
+    public AuthResponseDto authenticateUser(String username, String password) throws InvalidCredentialsException, BadRequestException {
         if(StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
             throw new BadRequestException("USERNAME_OR_PASSWORD_CAN_NOT_BE_NULL");
         }
-        try {
 
+        try {
             authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(username, password)
             );
 
             final UserDetails userDetails = userDetailsService.loadUserByUsername(username);
 
-            return jwtUtil.generateToken(userDetails.getUsername());
+            final String accessToken = jwtUtil.generateToken(userDetails.getUsername());
+            final String refreshToken = refreshTokenService.createRefreshToken(userDetails.getUsername());
+
+            return new AuthResponseDto(accessToken, refreshToken);
 
         } catch (AuthenticationException e) {
-            throw new Exception("Invalid username or password", e);
+            throw new InvalidCredentialsException("Invalid username or password");
         }
     }
-}
 
+    public AuthResponseDto refreshAccessToken(String refreshToken) throws InvalidTokenException, TokenExpiredException {
+        RefreshToken storedRefreshToken = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new InvalidTokenException("Invalid refresh token"));
+
+        if (storedRefreshToken.getExpireAt().isBefore(Instant.now())) {
+            refreshTokenService.deleteRefreshToken(storedRefreshToken.getToken());
+            throw new TokenExpiredException("Refresh token has expired");
+        }
+
+        AppUser user = storedRefreshToken.getAppUser();
+
+        UserDetails userDetails = userService.loadUserByUsername(user.getUsername());
+
+        String newRefreshToken = refreshTokenService.createRefreshToken(userDetails.getUsername());
+        String newAccessToken = jwtUtil.generateToken(userDetails.getUsername());
+
+        refreshTokenService.deleteRefreshToken(storedRefreshToken.getToken());
+
+        return new AuthResponseDto(newAccessToken, newRefreshToken);
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/service/AuthenticationService.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/service/AuthenticationService.java
@@ -63,7 +63,7 @@ public class AuthenticationService {
         }
     }
 
-    public AuthResponseDto refreshAccessToken(String refreshToken) throws InvalidTokenException, TokenExpiredException {
+    public AuthResponseDto refreshAccessToken(String refreshToken) throws TokenExpiredException, InvalidTokenException {
         RefreshToken storedRefreshToken = refreshTokenService.getRefreshToken(refreshToken);
 
         if (storedRefreshToken.getExpireAt().isBefore(Instant.now())) {

--- a/src/main/java/fr/nelson/you_are_the_hero/service/RefreshTokenService.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/service/RefreshTokenService.java
@@ -1,0 +1,48 @@
+package fr.nelson.you_are_the_hero.service;
+
+import fr.nelson.you_are_the_hero.model.db.RefreshToken;
+import fr.nelson.you_are_the_hero.repository.RefreshTokenRepository;
+import fr.nelson.you_are_the_hero.utility.JwtUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+public class RefreshTokenService {
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    JwtUtil jwtUtil;
+
+    @Value("${jwt.refresh-validity}")
+    private int REFRESH_TOKEN_VALIDITY;
+
+    public String createRefreshToken(String username) {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken(generateRefreshtoken());
+        refreshToken.setAppUser(userService.findAppUserByUsername(username));
+        refreshToken.setExpireAt(Instant.now().plusMillis(REFRESH_TOKEN_VALIDITY));
+
+        refreshTokenRepository.save(refreshToken);
+
+        return refreshToken.getToken();
+    }
+
+    public void deleteRefreshToken(String refreshToken){
+        refreshTokenRepository.deleteByToken(refreshToken);
+    }
+
+    private String generateRefreshtoken(){
+        return UUID.randomUUID().toString();
+    }
+
+
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/service/RefreshTokenService.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/service/RefreshTokenService.java
@@ -1,5 +1,6 @@
 package fr.nelson.you_are_the_hero.service;
 
+import fr.nelson.you_are_the_hero.exception.InvalidTokenException;
 import fr.nelson.you_are_the_hero.model.db.RefreshToken;
 import fr.nelson.you_are_the_hero.repository.RefreshTokenRepository;
 import fr.nelson.you_are_the_hero.utility.JwtUtil;
@@ -20,16 +21,16 @@ public class RefreshTokenService {
     private UserService userService;
 
     @Autowired
-    JwtUtil jwtUtil;
+    private JwtUtil jwtUtil;
 
     @Value("${jwt.refresh-validity}")
-    private int REFRESH_TOKEN_VALIDITY;
+    private int refreshTokenValidity;
 
     public String createRefreshToken(String username) {
         RefreshToken refreshToken = new RefreshToken();
         refreshToken.setToken(generateRefreshtoken());
         refreshToken.setAppUser(userService.findAppUserByUsername(username));
-        refreshToken.setExpireAt(Instant.now().plusMillis(REFRESH_TOKEN_VALIDITY));
+        refreshToken.setExpireAt(Instant.now().plusMillis(refreshTokenValidity));
 
         refreshTokenRepository.save(refreshToken);
 
@@ -38,6 +39,12 @@ public class RefreshTokenService {
 
     public void deleteRefreshToken(String refreshToken){
         refreshTokenRepository.deleteByToken(refreshToken);
+    }
+
+    public RefreshToken getRefreshToken(String refreshToken) throws InvalidTokenException {
+        RefreshToken storedRefreshToken = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new InvalidTokenException("Invalid refresh token"));
+        return storedRefreshToken;
     }
 
     private String generateRefreshtoken(){

--- a/src/main/java/fr/nelson/you_are_the_hero/service/UserService.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/service/UserService.java
@@ -3,13 +3,11 @@ package fr.nelson.you_are_the_hero.service;
 import fr.nelson.you_are_the_hero.model.db.AppUser;
 import fr.nelson.you_are_the_hero.repository.AppUserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -41,6 +39,10 @@ public class UserService implements UserDetailsService {
         }
         appUser.setPassword(passwordEncoder.encode(appUser.getPassword()));
         return appUserRepository.save(appUser);
+    }
+
+    public AppUser findAppUserByUsername(String username){
+        return appUserRepository.findByUsername(username);
     }
 
 }

--- a/src/main/java/fr/nelson/you_are_the_hero/utility/JwtUtil.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/utility/JwtUtil.java
@@ -18,13 +18,13 @@ import java.util.function.Function;
 public class JwtUtil {
 
     @Value("${jwt.secret}")
-    private String SECRET_KEY;
+    private String secretKey;
     @Value("${jwt.validity}")
-    private int ACCESS_TOKEN_VALIDITY;
+    private int accessTokenValidity;
 
     public String generateToken(String username) {
         Map<String, Object> claims = new HashMap<>();
-        return createToken(claims, username, ACCESS_TOKEN_VALIDITY);
+        return createToken(claims, username, accessTokenValidity);
     }
 
     private String createToken(Map<String, Object> claims, String subject, int tokenValidity) {
@@ -33,7 +33,7 @@ public class JwtUtil {
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
                 .setExpiration(new Date(System.currentTimeMillis() + tokenValidity))
-                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
     }
 
@@ -48,7 +48,7 @@ public class JwtUtil {
 
     private Claims extractAllClaims(String token) {
         return Jwts.parser()
-                .verifyWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)))
+                .verifyWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
                 .build().parseSignedClaims(token)
                 .getPayload();
     }

--- a/src/main/java/fr/nelson/you_are_the_hero/utility/JwtUtil.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/utility/JwtUtil.java
@@ -19,19 +19,20 @@ public class JwtUtil {
 
     @Value("${jwt.secret}")
     private String SECRET_KEY;
-    private final int VALIDITY = 1000 * 60 * 60 * 10;
+    @Value("${jwt.validity}")
+    private int ACCESS_TOKEN_VALIDITY;
 
     public String generateToken(String username) {
         Map<String, Object> claims = new HashMap<>();
-        return createToken(claims, username);
+        return createToken(claims, username, ACCESS_TOKEN_VALIDITY);
     }
 
-    private String createToken(Map<String, Object> claims, String subject) {
+    private String createToken(Map<String, Object> claims, String subject, int tokenValidity) {
         return Jwts.builder()
-                .claims(claims)
-                .subject(subject)
-                .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(new Date(System.currentTimeMillis() + VALIDITY))
+                .setClaims(claims)
+                .setSubject(subject)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + tokenValidity))
                 .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
                 .compact();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,8 @@
-welcome.message.fr = Prout.
-welcome.message.en = Welcome, Awakened Traveler. The world you are about to explore is a place of endless mysteries and wonders. You are about to immerse yourself in an extraordinary journey through magical realms that defy imagination and awaken the soul. You are the Pilgrim. Armed with an insatiable curiosity and guided by a sacred quest, you are the explorer of forgotten kingdoms and enchanted lands. Your destiny is tied to the search for ancient secrets, powerful artifacts, and hidden truths that shape the invisible threads of the magical world. Your adventure begins here. Each world you visit has its own mysteries to uncover, challenges to overcome, and inhabitants to understand. Your grimoire, your skills, and your spirit of adventure will be your allies in this quest. The trials you will encounter are just the first steps of a journey that could forever change your understanding of magic and the world. Prepare to explore the unknown. Portals to other dimensions open before you, secrets unfold, and legends come to life. You have been chosen for this quest because you possess the courage, wisdom, and determination needed to confront what lies hidden in the shadows of the magical realms. Let the journey begin. Take a deep breath, open the eyes of your mind, and step into the adventure. The fate of the worlds is in your hands.
 spring.data.mongodb.uri=mongodb://localhost:27017/game_db
 
+# Token validity 15 minutes
+jwt.validity = 900000
+# Refresh Token validity 1 week
+jwt.refresh-validity = 604800000
+# Secret for dev not for prod
 jwt.secret = "secretkeybeaucouppluslongueszelioflsjkdfhksjqhdbvjhkdsbfvujykqsbdvikb"

--- a/src/test/java/fr/nelson/you_are_the_hero/service/AuthenticationServiceTest.java
+++ b/src/test/java/fr/nelson/you_are_the_hero/service/AuthenticationServiceTest.java
@@ -108,7 +108,7 @@ public class AuthenticationServiceTest {
         refreshToken.setAppUser(appUser);
         refreshToken.setExpireAt(Instant.now().plusMillis(10000));
 
-        when(refreshTokenRepository.findByToken("valid_refresh_token")).thenReturn(Optional.of(refreshToken));
+        when(refreshTokenService.getRefreshToken("valid_refresh_token")).thenReturn(refreshToken);
         when(userService.loadUserByUsername("user")).thenReturn(userDetails);
         when(refreshTokenService.createRefreshToken("user")).thenReturn("new_refresh_token");
         when(jwtUtil.generateToken("user")).thenReturn("new_access_token");
@@ -123,8 +123,8 @@ public class AuthenticationServiceTest {
     }
 
     @Test
-    public void refreshAccessToken_InvalidToken() {
-        when(refreshTokenRepository.findByToken("invalid_refresh_token")).thenReturn(Optional.empty());
+    public void refreshAccessToken_InvalidToken() throws InvalidTokenException {
+        when(refreshTokenService.getRefreshToken("invalid_refresh_token")).thenThrow(new InvalidTokenException("Invalid refresh token"));
 
         Assertions.assertThrows(InvalidTokenException.class, () -> {
             authenticationService.refreshAccessToken("invalid_refresh_token");
@@ -132,7 +132,7 @@ public class AuthenticationServiceTest {
     }
 
     @Test
-    public void refreshAccessToken_ExpiredToken() {
+    public void refreshAccessToken_ExpiredToken() throws InvalidTokenException {
         AppUser appUser = new AppUser();
         appUser.setUsername("user");
 
@@ -141,7 +141,7 @@ public class AuthenticationServiceTest {
         refreshToken.setAppUser(appUser);
         refreshToken.setExpireAt(Instant.now().minusMillis(10000));
 
-        when(refreshTokenRepository.findByToken("valid_refresh_token")).thenReturn(Optional.of(refreshToken));
+        when(refreshTokenService.getRefreshToken("valid_refresh_token")).thenReturn(refreshToken);
 
         Assertions.assertThrows(TokenExpiredException.class, () -> {
             authenticationService.refreshAccessToken("valid_refresh_token");
@@ -151,7 +151,7 @@ public class AuthenticationServiceTest {
     }
 
     @Test
-    public void refreshAccessToken_UserNotFound() {
+    public void refreshAccessToken_UserNotFound() throws InvalidTokenException {
         AppUser appUser = new AppUser();
         appUser.setUsername("user");
 
@@ -160,7 +160,7 @@ public class AuthenticationServiceTest {
         refreshToken.setAppUser(appUser);
         refreshToken.setExpireAt(Instant.now().plusMillis(10000));
 
-        when(refreshTokenRepository.findByToken("valid_refresh_token")).thenReturn(Optional.of(refreshToken));
+        when(refreshTokenService.getRefreshToken("valid_refresh_token")).thenReturn(refreshToken);
         when(userService.loadUserByUsername("user")).thenThrow(new UsernameNotFoundException("User not found"));
 
         Assertions.assertThrows(UsernameNotFoundException.class, () -> {

--- a/src/test/java/fr/nelson/you_are_the_hero/service/AuthenticationServiceTest.java
+++ b/src/test/java/fr/nelson/you_are_the_hero/service/AuthenticationServiceTest.java
@@ -1,5 +1,11 @@
 package fr.nelson.you_are_the_hero.service;
 
+import fr.nelson.you_are_the_hero.exception.InvalidTokenException;
+import fr.nelson.you_are_the_hero.exception.TokenExpiredException;
+import fr.nelson.you_are_the_hero.model.db.AppUser;
+import fr.nelson.you_are_the_hero.model.db.RefreshToken;
+import fr.nelson.you_are_the_hero.model.dto.AuthResponseDto;
+import fr.nelson.you_are_the_hero.repository.RefreshTokenRepository;
 import fr.nelson.you_are_the_hero.utility.JwtUtil;
 import org.apache.coyote.BadRequestException;
 import org.junit.jupiter.api.Assertions;
@@ -11,10 +17,15 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class AuthenticationServiceTest {
@@ -30,6 +41,15 @@ public class AuthenticationServiceTest {
 
     @Mock
     private JwtUtil jwtUtil;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private UserService userService;
 
     @Test
     public void testAuthenticateUserWithNullUsername_throwBRE() {
@@ -53,19 +73,99 @@ public class AuthenticationServiceTest {
 
     @Test
     public void testAuthenticateUserWithRightCreds_OK() throws Exception {
-        Mockito.when(authenticationManager.authenticate(Mockito.any())).thenReturn(null);
-        Mockito.when(this.userDetailsService.loadUserByUsername(Mockito.any())).thenReturn(User.withUsername("user")
+        when(authenticationManager.authenticate(Mockito.any())).thenReturn(null);
+        when(this.userDetailsService.loadUserByUsername(Mockito.any())).thenReturn(User.withUsername("user")
                 .password("password")
                 .build());
-        Mockito.when(this.jwtUtil.generateToken(Mockito.any())).thenReturn("123");
-        Assertions.assertEquals("123", this.authenticationService.authenticateUser("user", "password"));
+        when(this.jwtUtil.generateToken(Mockito.any())).thenReturn("access-token-123");
+        when(this.refreshTokenService.createRefreshToken(Mockito.any())).thenReturn("refresh-token-123");
+
+        AuthResponseDto response = this.authenticationService.authenticateUser("user", "password");
+
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals("access-token-123", response.getAccessToken());
+        Assertions.assertEquals("refresh-token-123", response.getRefreshToken());
     }
 
     @Test
     public void testAuthenticateUserWithWhrongtCreds_OK() {
-        Mockito.when(authenticationManager.authenticate(Mockito.any())).thenThrow(new BadCredentialsException("log exception"));
+        when(authenticationManager.authenticate(Mockito.any())).thenThrow(new BadCredentialsException("log exception"));
         Assertions.assertThrows(Exception.class, () -> this.authenticationService.authenticateUser("user", "password"));
     }
 
+    @Test
+    public void refreshAccessToken_Success() throws Exception {
+        AppUser appUser = new AppUser();
+        appUser.setUsername("user");
+
+        UserDetails userDetails = User.withUsername("user")
+                .password("password")
+                .roles("USER")
+                .build();
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken("valid_refresh_token");
+        refreshToken.setAppUser(appUser);
+        refreshToken.setExpireAt(Instant.now().plusMillis(10000));
+
+        when(refreshTokenRepository.findByToken("valid_refresh_token")).thenReturn(Optional.of(refreshToken));
+        when(userService.loadUserByUsername("user")).thenReturn(userDetails);
+        when(refreshTokenService.createRefreshToken("user")).thenReturn("new_refresh_token");
+        when(jwtUtil.generateToken("user")).thenReturn("new_access_token");
+
+        AuthResponseDto response = authenticationService.refreshAccessToken("valid_refresh_token");
+
+        Assertions.assertNotNull(response);
+        Assertions.assertEquals("new_access_token", response.getAccessToken());
+        Assertions.assertEquals("new_refresh_token", response.getRefreshToken());
+
+        Mockito.verify(refreshTokenService).deleteRefreshToken("valid_refresh_token");
+    }
+
+    @Test
+    public void refreshAccessToken_InvalidToken() {
+        when(refreshTokenRepository.findByToken("invalid_refresh_token")).thenReturn(Optional.empty());
+
+        Assertions.assertThrows(InvalidTokenException.class, () -> {
+            authenticationService.refreshAccessToken("invalid_refresh_token");
+        });
+    }
+
+    @Test
+    public void refreshAccessToken_ExpiredToken() {
+        AppUser appUser = new AppUser();
+        appUser.setUsername("user");
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken("valid_refresh_token");
+        refreshToken.setAppUser(appUser);
+        refreshToken.setExpireAt(Instant.now().minusMillis(10000));
+
+        when(refreshTokenRepository.findByToken("valid_refresh_token")).thenReturn(Optional.of(refreshToken));
+
+        Assertions.assertThrows(TokenExpiredException.class, () -> {
+            authenticationService.refreshAccessToken("valid_refresh_token");
+        });
+
+        Mockito.verify(refreshTokenService).deleteRefreshToken("valid_refresh_token");
+    }
+
+    @Test
+    public void refreshAccessToken_UserNotFound() {
+        AppUser appUser = new AppUser();
+        appUser.setUsername("user");
+
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken("valid_refresh_token");
+        refreshToken.setAppUser(appUser);
+        refreshToken.setExpireAt(Instant.now().plusMillis(10000));
+
+        when(refreshTokenRepository.findByToken("valid_refresh_token")).thenReturn(Optional.of(refreshToken));
+        when(userService.loadUserByUsername("user")).thenThrow(new UsernameNotFoundException("User not found"));
+
+        Assertions.assertThrows(UsernameNotFoundException.class, () -> {
+            authenticationService.refreshAccessToken("valid_refresh_token");
+        });
+    }
 }
 

--- a/src/test/java/fr/nelson/you_are_the_hero/service/RefreshTokenServiceTest.java
+++ b/src/test/java/fr/nelson/you_are_the_hero/service/RefreshTokenServiceTest.java
@@ -1,0 +1,49 @@
+package fr.nelson.you_are_the_hero.service;
+
+import fr.nelson.you_are_the_hero.model.db.AppUser;
+import fr.nelson.you_are_the_hero.model.db.RefreshToken;
+import fr.nelson.you_are_the_hero.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class RefreshTokenServiceTest {
+    @InjectMocks
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Test
+    void testCreateRefreshToken_Success() {
+        String username = "user";
+        AppUser appUser = new AppUser();
+        appUser.setUsername(username);
+
+        when(userService.findAppUserByUsername(username)).thenReturn(appUser);
+
+        String refreshToken = refreshTokenService.createRefreshToken(username);
+
+        Assertions.assertNotNull(refreshToken);
+
+        verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+    }
+
+    @Test
+    void testDeleteRefreshToken_Success() {
+        String refreshToken = "test-refresh-token";
+
+        refreshTokenService.deleteRefreshToken(refreshToken);
+
+        verify(refreshTokenRepository, times(1)).deleteByToken(refreshToken);
+    }
+}

--- a/src/test/java/fr/nelson/you_are_the_hero/service/RefreshTokenServiceTest.java
+++ b/src/test/java/fr/nelson/you_are_the_hero/service/RefreshTokenServiceTest.java
@@ -1,5 +1,6 @@
 package fr.nelson.you_are_the_hero.service;
 
+import fr.nelson.you_are_the_hero.exception.InvalidTokenException;
 import fr.nelson.you_are_the_hero.model.db.AppUser;
 import fr.nelson.you_are_the_hero.model.db.RefreshToken;
 import fr.nelson.you_are_the_hero.repository.RefreshTokenRepository;
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 
@@ -45,5 +48,29 @@ public class RefreshTokenServiceTest {
         refreshTokenService.deleteRefreshToken(refreshToken);
 
         verify(refreshTokenRepository, times(1)).deleteByToken(refreshToken);
+    }
+
+    @Test
+    public void getRefreshToken_ValidToken() throws InvalidTokenException {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setToken("valid_refresh_token");
+
+        when(refreshTokenRepository.findByToken("valid_refresh_token")).thenReturn(Optional.of(refreshToken));
+
+        RefreshToken result = refreshTokenService.getRefreshToken("valid_refresh_token");
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("valid_refresh_token", result.getToken());
+    }
+
+    @Test
+    public void getRefreshToken_InvalidToken() {
+        when(refreshTokenRepository.findByToken("invalid_refresh_token")).thenReturn(Optional.empty());
+
+        InvalidTokenException exception = Assertions.assertThrows(InvalidTokenException.class, () -> {
+            refreshTokenService.getRefreshToken("invalid_refresh_token");
+        });
+
+        Assertions.assertEquals("Invalid refresh token", exception.getMessage());
     }
 }


### PR DESCRIPTION
### Context
This PR close #2, which aims to enhance the authentication system by adding a refresh token mechanism. This will allow users to extend their session without needing to re-authenticate, improving user experience and security.

### Changes
- Added a refresh token service that generates, stores, and validates refresh tokens.
- Updated authentication logic to include handling of refresh tokens.
- Implemented methods to delete expired refresh tokens from the database.
- Added unit tests to ensure the functionality of the refresh token system.