### PR TITLE
feat(admin): implement Admin API Security

### DIFF
--- a/src/main/java/fr/nelson/you_are_the_hero/configuration/SecurityConfig.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/configuration/SecurityConfig.java
@@ -1,6 +1,8 @@
 package fr.nelson.you_are_the_hero.configuration;
 
+import fr.nelson.you_are_the_hero.filter.ApiKeyAuthenticationFilter;
 import fr.nelson.you_are_the_hero.filter.AuthenticationFilter;
+import fr.nelson.you_are_the_hero.service.ApiKeyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,14 +25,19 @@ public class SecurityConfig {
 
     @Autowired
     @Lazy
+    ApiKeyAuthenticationFilter apiKeyAuthenticationFilter;
+
+    @Autowired
+    @Lazy
     private AuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf().disable()
+                .addFilterBefore(apiKeyAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry
-                                .requestMatchers("/","/auth/**").permitAll()
+                                .requestMatchers("/","/auth/**", "/auth/admin").permitAll()
                                 .anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/src/main/java/fr/nelson/you_are_the_hero/controller/AuthenticationController.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/controller/AuthenticationController.java
@@ -1,5 +1,6 @@
 package fr.nelson.you_are_the_hero.controller;
 
+import fr.nelson.you_are_the_hero.exception.AdminAlreadyExistException;
 import fr.nelson.you_are_the_hero.exception.InvalidTokenException;
 import fr.nelson.you_are_the_hero.exception.TokenExpiredException;
 import fr.nelson.you_are_the_hero.model.db.AppUser;
@@ -113,6 +114,23 @@ public class AuthenticationController {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(messageDto);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("An unexpected error occurred : " + e.getMessage());
+        }
+
+    }
+
+    @PostMapping("/admin")
+    public ResponseEntity<?> createAdmin(@RequestBody UserDto userDto){
+        MessageDto messageDto = new MessageDto();
+        try{
+            AppUser appUser = userService.createAdminUser(userDto);
+            messageDto.setMessage(appUser.getUsername() + " is now an admin");
+            return ResponseEntity.ok(messageDto);
+        } catch (AdminAlreadyExistException e) {
+            messageDto.setMessage(e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(messageDto);
+        } catch (UsernameNotFoundException e) {
+            messageDto.setMessage(e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(messageDto);
         }
 
     }

--- a/src/main/java/fr/nelson/you_are_the_hero/exception/AdminAlreadyExistException.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/exception/AdminAlreadyExistException.java
@@ -1,0 +1,7 @@
+package fr.nelson.you_are_the_hero.exception;
+
+public class AdminAlreadyExistException extends RuntimeException {
+    public AdminAlreadyExistException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/filter/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/filter/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,69 @@
+package fr.nelson.you_are_the_hero.filter;
+
+import fr.nelson.you_are_the_hero.service.ApiKeyService;
+import fr.nelson.you_are_the_hero.service.FailedAttemptService;
+import fr.nelson.you_are_the_hero.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    ApiKeyService apiKeyService;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    FailedAttemptService failedAttemptService;
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiKeyAuthenticationFilter.class);
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if(!apiKeyService.isComformApiKey()){
+            logger.error("Your Admin Key is no confrom to Base64 256bit");
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+
+        String userIp = request.getRemoteAddr();
+
+        if (failedAttemptService.isBlocked(userIp)) {
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            logger.warn("User with IP {} was blocked", userIp);
+            return;
+        }
+
+        if(request.getRequestURI().startsWith("/auth/admin")){
+            if(userService.isAlreadyAnAdmin()){
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                return;
+            }
+
+            String apiKeyHeader = request.getHeader("ADMIN_KEY");
+
+            if(apiKeyHeader == null || !apiKeyService.isValidApiKey(apiKeyHeader)){
+                failedAttemptService.registerFailedAttempt(userIp);
+                logger.info("Admin key used is incorrect; {}", userIp);
+                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                return;
+            }
+
+            failedAttemptService.resetAttempts(userIp);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/filter/AuthenticationFilter.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/filter/AuthenticationFilter.java
@@ -26,9 +26,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
     private UserDetailsService userDetailsService;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
-
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         final String authorizationHeader = request.getHeader("Authorization");
 
         String username = null;

--- a/src/main/java/fr/nelson/you_are_the_hero/model/dto/UserDto.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/model/dto/UserDto.java
@@ -5,6 +5,9 @@ import org.springframework.hateoas.RepresentationModel;
 public class UserDto  extends RepresentationModel<StoryDto> {
     String username;
 
+    public UserDto() {
+    }
+
     public UserDto(String username) {
         this.username = username;
     }

--- a/src/main/java/fr/nelson/you_are_the_hero/repository/AppUserRepository.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/repository/AppUserRepository.java
@@ -1,12 +1,14 @@
 package fr.nelson.you_are_the_hero.repository;
 
 import fr.nelson.you_are_the_hero.model.db.AppUser;
+import fr.nelson.you_are_the_hero.model.db.Role;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface AppUserRepository extends MongoRepository<AppUser, String> {
     AppUser findByUsername(String username);
+    boolean existsByRole(Role role);
     boolean existsByUsername(String username);
 }
 

--- a/src/main/java/fr/nelson/you_are_the_hero/service/ApiKeyService.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/service/ApiKeyService.java
@@ -1,0 +1,33 @@
+package fr.nelson.you_are_the_hero.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Base64;
+
+@Service
+public class ApiKeyService {
+    @Value("${admin.secret.key}")
+    private String adminSecretKey;
+
+    public void setAdminSecretKey(String adminSecretKey) {
+        this.adminSecretKey = adminSecretKey;
+    }
+
+    public boolean isValidApiKey(String key){
+        return adminSecretKey.equals(key);
+    }
+
+    public boolean isComformApiKey() {
+        if (adminSecretKey == null || adminSecretKey.isEmpty()) {
+            return false;
+        }
+
+        try {
+            byte[] decodedKey = Base64.getDecoder().decode(adminSecretKey);
+            return decodedKey.length == 32;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/fr/nelson/you_are_the_hero/service/FailedAttemptService.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/service/FailedAttemptService.java
@@ -1,0 +1,54 @@
+package fr.nelson.you_are_the_hero.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class FailedAttemptService {
+
+    private final Map<String, Integer> attemptsCache = new HashMap<>();
+    private final Map<String, Long> blockedUsers = new HashMap<>();
+    @Value("${admin.try.attempts}")
+    private int maxAttempts;
+    @Value("${block.duration}")
+    private long blockTime;
+
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    public void setBlockTime(long blockTime) {
+        this.blockTime = blockTime;
+    }
+
+    public void registerFailedAttempt(String userIp) {
+        int attempts = attemptsCache.getOrDefault(userIp, 0) + 1;
+        attemptsCache.put(userIp, attempts);
+
+        if (attempts >= maxAttempts) {
+            blockedUsers.put(userIp, System.currentTimeMillis() + blockTime);
+            attemptsCache.remove(userIp);
+        }
+    }
+
+    public boolean isBlocked(String userIp) {
+        Long blockedUntil = blockedUsers.get(userIp);
+        if (blockedUntil == null) {
+            return false;
+        }
+
+        if (System.currentTimeMillis() > blockedUntil) {
+            blockedUsers.remove(userIp);
+            return false;
+        }
+        return true;
+    }
+
+    public void resetAttempts(String userIp) {
+        attemptsCache.remove(userIp);
+    }
+}
+

--- a/src/main/java/fr/nelson/you_are_the_hero/service/UserService.java
+++ b/src/main/java/fr/nelson/you_are_the_hero/service/UserService.java
@@ -1,8 +1,11 @@
 package fr.nelson.you_are_the_hero.service;
 
+import fr.nelson.you_are_the_hero.exception.AdminAlreadyExistException;
 import fr.nelson.you_are_the_hero.exception.UserAllreadyExistException;
 import fr.nelson.you_are_the_hero.model.db.AppUser;
+import fr.nelson.you_are_the_hero.model.db.Role;
 import fr.nelson.you_are_the_hero.model.dto.AuthRequestDto;
+import fr.nelson.you_are_the_hero.model.dto.UserDto;
 import fr.nelson.you_are_the_hero.repository.AppUserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.User;
@@ -54,4 +57,23 @@ public class UserService implements UserDetailsService {
         return appUser;
     }
 
+    public AppUser createAdminUser(UserDto UserDto) throws AdminAlreadyExistException, UsernameNotFoundException{
+        if(isAlreadyAnAdmin()){
+            throw new AdminAlreadyExistException("Admin allready exist");
+        }
+
+        AppUser appUser = appUserRepository.findByUsername(UserDto.getUsername());
+
+        if(appUser == null) {
+            throw new UsernameNotFoundException("User Not Found");
+        }
+
+        appUser.setRole(Role.ADMIN);
+
+        return appUserRepository.save(appUser);
+    }
+
+    public boolean isAlreadyAnAdmin() {
+        return appUserRepository.existsByRole(Role.ADMIN);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,15 @@ spring.data.mongodb.uri=mongodb://localhost:27017/game_db
 jwt.validity = 900000
 # Refresh Token validity 1 week
 jwt.refresh-validity = 604800000
-# Secret for dev not for prod
+# Secret for prod
+#jwt.secret = ${JWT_SECRET_KEY}
+# Secret for dev
 jwt.secret = "secretkeybeaucouppluslongueszelioflsjkdfhksjqhdbvjhkdsbfvujykqsbdvikb"
+
+#secret keys for admin creation for prod
+#admin.secret.key = ${ADMIN_SECRET_KEY}
+#secret keys for admin creation for dev
+admin.secret.key = L4JAjUvWkHvZ23Im5TinkouRZEIbEboTSxYfjD1JB/E=
+
+admin.try.attempts = 3
+block.duration = 600000

--- a/src/test/java/fr/nelson/you_are_the_hero/service/ApiKeyServiceTest.java
+++ b/src/test/java/fr/nelson/you_are_the_hero/service/ApiKeyServiceTest.java
@@ -1,0 +1,53 @@
+package fr.nelson.you_are_the_hero.service;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+public class ApiKeyServiceTest {
+    @InjectMocks
+    ApiKeyService apiKeyService;
+
+    @Test
+    public void testIsValidApiKey_ValidKey() {
+        String validKey = "this_is_a_256_bit_key_12345678";
+        apiKeyService.setAdminSecretKey(validKey);
+        assertTrue(apiKeyService.isValidApiKey(validKey));
+    }
+
+    @Test
+    public void testIsValidApiKey_InvalidKey() {
+        String validKey = "this_is_a_256_bit_key_12345678";
+        apiKeyService.setAdminSecretKey(validKey);
+        assertFalse(apiKeyService.isValidApiKey("invalid_key"));
+    }
+
+    @Test
+    public void testIsComformApiKey_ValidKey() {
+        String validKey = "xG1N1N2KXOT2UeF1Y9XkZGRjMT1gE2LR2I8Y6H3y5qA=";
+        apiKeyService.setAdminSecretKey(validKey);
+        assertTrue(apiKeyService.isComformApiKey());
+    }
+
+    @Test
+    public void testIsComformApiKey_NullKey() {
+        apiKeyService.setAdminSecretKey(null);
+        assertFalse(apiKeyService.isComformApiKey());
+    }
+
+    @Test
+    public void testIsComformApiKey_EmptyKey() {
+        apiKeyService.setAdminSecretKey("");
+        assertFalse(apiKeyService.isComformApiKey());
+    }
+
+    @Test
+    public void testIsComformApiKey_InvalidBase64() {
+        apiKeyService.setAdminSecretKey("invalid_base64_key");
+        assertFalse(apiKeyService.isComformApiKey());
+    }
+}

--- a/src/test/java/fr/nelson/you_are_the_hero/service/FailedAttemptServiceTest.java
+++ b/src/test/java/fr/nelson/you_are_the_hero/service/FailedAttemptServiceTest.java
@@ -1,0 +1,4 @@
+package fr.nelson.you_are_the_hero.service;
+
+public class FailedAttemptServiceTest {
+}

--- a/src/test/java/fr/nelson/you_are_the_hero/service/UserServiceTest.java
+++ b/src/test/java/fr/nelson/you_are_the_hero/service/UserServiceTest.java
@@ -1,9 +1,11 @@
 package fr.nelson.you_are_the_hero.service;
 
+import fr.nelson.you_are_the_hero.exception.AdminAlreadyExistException;
 import fr.nelson.you_are_the_hero.exception.UserAllreadyExistException;
 import fr.nelson.you_are_the_hero.model.db.AppUser;
 import fr.nelson.you_are_the_hero.model.db.Role;
 import fr.nelson.you_are_the_hero.model.dto.AuthRequestDto;
+import fr.nelson.you_are_the_hero.model.dto.UserDto;
 import fr.nelson.you_are_the_hero.repository.AppUserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -104,5 +106,67 @@ public class UserServiceTest {
             userService.loadUserByUsername("unknown-username");
         });
 
+    }
+
+    @Test
+    public void testCreateAdminUser_Ok() {
+        AppUser appUser = new AppUser();
+        appUser.setUsername("jean neige");
+        appUser.setPassword("Ygrid");
+        appUser.setRole(Role.PLAYER);
+
+        UserDto userDto = new UserDto("jean neige");
+
+        when(userService.isAlreadyAnAdmin()).thenReturn(false);
+        when(appUserRepository.findByUsername("jean neige")).thenReturn(appUser);
+        when(appUserRepository.save(appUser)).thenReturn(appUser);
+
+        AppUser adminUser = userService.createAdminUser(userDto);
+
+        assertNotNull(adminUser);
+        assertEquals("jean neige", adminUser.getUsername());
+        assertEquals(Role.ADMIN, adminUser.getRole());
+
+        verify(appUserRepository).save(appUser);
+    }
+
+    @Test
+    public void testCreateAdminUser_AdminExists() {
+        UserDto userDto = new UserDto("jean neige");
+
+        when(userService.isAlreadyAnAdmin()).thenReturn(true);
+
+        assertThrows(AdminAlreadyExistException.class, () -> {
+            userService.createAdminUser(userDto);
+        });
+    }
+
+    @Test
+    public void testCreateAdminUser_WithInexistingAppUser() {
+        UserDto userDto = new UserDto("jean neige");
+
+        when(appUserRepository.findByUsername(Mockito.anyString())).thenReturn(null);
+
+        assertThrows(UsernameNotFoundException.class, () -> {
+            userService.createAdminUser(userDto);
+        });
+    }
+
+    @Test
+    public void testIsAlreadyAnAdmin_NoAdminExist() {
+        when(appUserRepository.existsByRole(Role.ADMIN)).thenReturn(false);
+
+        Boolean isAnAdmin = userService.isAlreadyAnAdmin();
+
+        assertFalse(isAnAdmin);
+    }
+
+    @Test
+    public void testIsAlreadyAnAdmin_AdminExist() {
+        when(appUserRepository.existsByRole(Role.ADMIN)).thenReturn(true);
+
+        Boolean isAnAdmin = userService.isAlreadyAnAdmin();
+
+        assertTrue(isAnAdmin);
     }
 }


### PR DESCRIPTION
### Description:

This PR introduces several key improvements to enhance the security of the Admin API, ensuring robust authentication, protection against brute-force attacks, and better control of admin user creation. Close #42.

### Admin Key Validation:

- Implemented a service to validate the admin key (ADMIN_KEY) provided in API requests.
- Ensured the admin key follows a Base64-encoded 256-bit standard.
- Added a log warning for non-conforming admin keys to alert developers during deployment.

### Failed Attempt Blocking:

- Introduced FailedAttemptService to track failed API key attempts and block access after 3 consecutive failures.
- Users are blocked for a configurable time (e.g., 15 minutes) after exceeding the allowed number of attempts.
- IP addresses are used to track individual users and enforce the blocking mechanism.
- Failed attempts are reset upon successful API key validation.

### Admin Creation Logic:

- Implemented checks to prevent creating multiple admin users (isAlreadyAnAdmin method).
- Added exception handling to gracefully handle cases where an admin already exists or if the user to be promoted doesn't exist.
- Created the createAdminUser method.

### Future Considerations:

- Key Rotation: Implement a mechanism to rotate the admin API key securely without disrupting active requests.